### PR TITLE
Add more docs on toText and instance Show

### DIFF
--- a/src/Data/NonEmptyText.hs
+++ b/src/Data/NonEmptyText.hs
@@ -37,6 +37,9 @@ data NonEmptyText =
   NonEmptyText Char Text.Text
   deriving (Eq, Ord, NFData, Generic)
 
+-- |
+-- Note that this instance uses 'toText', so two unequal NonEmptyTexts might be
+-- unequal even though they 'show' the same
 instance Show NonEmptyText where
   show = show . toText
 
@@ -140,6 +143,8 @@ length = (1 +) . Text.length . Data.NonEmptyText.tail
 --
 -- The 'Data.Text.Text' result is guaranteed to be non-empty. However, this is
 -- not reflected in the type.
+-- Note that the first 'Char' may be replaced with U+FFFD,
+-- which happens when 'Data.Text.cons' would also replace it.
 toText :: NonEmptyText -> Text.Text
 toText = uncurry Text.cons . uncons
 


### PR DESCRIPTION
The documentation doesn't contains details on surrogate pairs, for example it doesn't say that the first Char is stored unmodified, but might be replaced when converted to Text. I am not sure the current behavior is desirable though, since it means that the Show instance is misleading: it looks like things are equal, when they are not:

```
ghci> Data.NonEmptyText.singleton '\xd801'
"\65533"
ghci> Data.NonEmptyText.singleton '\xd800'
"\65533"
ghci> Data.NonEmptyText.singleton '\xd800' == Data.NonEmptyText.singleton '\xd801'
False
```

I wonder whether it would make sense to have the NonEmptyText type exclusively store Text, since that it what the name suggests. Right now, by mixing Char and Text, we are likely to get issues like the one shown above, since we're mixing invariants from two separate string types (Char and Text). If the text library were to change their representation again, away from UTF-8, those invariants would change yet again. By having the NonEmptyText type use exclusively use stuff like `Data.Text.empty` instead of having a cons-style constructor, this library would have a higher likelihood of agreeing with the text library.